### PR TITLE
Add API key input in settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,10 @@ npm run dev
 4. Le système détectera automatiquement les changements de locuteur
 5. Générez le compte rendu final
 
+## Configuration de l'API
+
+Pour exploiter l'analyse OpenAI, ouvrez le menu **Paramètres** (icône en forme d'engrenage) et renseignez votre clé API dans le champ *Clé API OpenAI*. Cette clé est nécessaire pour générer les comptes rendus et les lettres.
+
 ## Notes de version
 - Version 2.0.0 : Refonte majeure de l'interface et des fonctionnalités
 - Amélioration significative de la détection des locuteurs

--- a/src/components/GlobalSettings.tsx
+++ b/src/components/GlobalSettings.tsx
@@ -4,13 +4,15 @@ import { useRecordingStore } from '../store/recordingStore';
 import type { AISettings } from '../types';
 
 export const GlobalSettings: React.FC = () => {
-  const { aiSettings, setAISettings, logoUrl, setLogoUrl } = useRecordingStore();
+  const { aiSettings, setAISettings, logoUrl, setLogoUrl, openAIApiKey, setOpenAIApiKey } = useRecordingStore();
   const [isOpen, setIsOpen] = useState(false);
   const [tempSettings, setTempSettings] = useState<AISettings>(aiSettings);
+  const [tempApiKey, setTempApiKey] = useState(openAIApiKey);
   const fileInputRef = useRef<HTMLInputElement>(null);
 
   const handleSave = () => {
     setAISettings(tempSettings);
+    setOpenAIApiKey(tempApiKey);
     setIsOpen(false);
   };
 
@@ -80,6 +82,19 @@ export const GlobalSettings: React.FC = () => {
                     </p>
                   </div>
                 </div>
+              </div>
+
+              <div className="border-b pb-4">
+                <label className="text-sm font-medium text-gray-700 mb-2 block">
+                  Clé API OpenAI
+                </label>
+                <input
+                  type="password"
+                  value={tempApiKey}
+                  onChange={(e) => setTempApiKey(e.target.value)}
+                  className="w-full border border-gray-300 rounded-md px-3 py-2"
+                  placeholder="Entrez votre clé API"
+                />
               </div>
 
               <div>

--- a/src/config/api.ts
+++ b/src/config/api.ts
@@ -1,11 +1,8 @@
-export const OPENAI_API_KEY = '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';
-export const DEEPGRAM_API_KEY = '2a16e46b879b0ba8e113cb0fd0a6fce6b5a38464';
-
 export const API_CONFIG = {
-  baseURL: 'https://api.openai.com/v1',
-  DEEPGRAM_API_KEY: DEEPGRAM_API_KEY,
-  headers: {
-    'Authorization': `Bearer ${OPENAI_API_KEY}`,
-    'Content-Type': 'application/json'
-  }
+  baseURL: 'https://api.openai.com/v1'
 };
+
+export const getOpenAIHeaders = (apiKey: string) => ({
+  'Authorization': `Bearer ${apiKey}`,
+  'Content-Type': 'application/json'
+});

--- a/src/services/transcription.ts
+++ b/src/services/transcription.ts
@@ -1,4 +1,4 @@
-import { API_CONFIG } from '../config/api';
+import { API_CONFIG, getOpenAIHeaders } from '../config/api';
 import { useRecordingStore } from '../store/recordingStore';
 import { handleAPIError } from '../utils/errorHandling';
 
@@ -90,11 +90,15 @@ export async function generateReport(transcription: string, template: string): P
   }
 
   try {
-    const { aiSettings } = useRecordingStore.getState();
+    const { aiSettings, openAIApiKey } = useRecordingStore.getState();
+
+    if (!openAIApiKey) {
+      throw new Error('Clé API OpenAI manquante. Veuillez la renseigner dans les paramètres.');
+    }
 
     const response = await fetch(`${API_CONFIG.baseURL}/chat/completions`, {
       method: 'POST',
-      headers: API_CONFIG.headers,
+      headers: getOpenAIHeaders(openAIApiKey),
       body: JSON.stringify({
         model: 'gpt-4o-mini-2024-07-18',
         messages: [
@@ -133,11 +137,15 @@ export async function generateReport(transcription: string, template: string): P
 
 export async function generateColleagueLetter(transcription: string, report: string): Promise<string> {
   try {
-    const { aiSettings, selectedLetterTemplate } = useRecordingStore.getState();
+    const { aiSettings, selectedLetterTemplate, openAIApiKey } = useRecordingStore.getState();
+
+    if (!openAIApiKey) {
+      throw new Error('Clé API OpenAI manquante. Veuillez la renseigner dans les paramètres.');
+    }
 
     const response = await fetch(`${API_CONFIG.baseURL}/chat/completions`, {
       method: 'POST',
-      headers: API_CONFIG.headers,
+      headers: getOpenAIHeaders(openAIApiKey),
       body: JSON.stringify({
         model: 'gpt-4o-mini-2024-07-18',
         messages: [

--- a/src/store/recordingStore.ts
+++ b/src/store/recordingStore.ts
@@ -83,6 +83,7 @@ export const useRecordingStore = create<RecordingState>((set) => ({
   isProcessing: false,
   error: null,
   aiSettings: DEFAULT_AI_SETTINGS,
+  openAIApiKey: localStorage.getItem('openAIApiKey') || '',
   logoUrl: '',
   setLogoUrl: (url) => set({ logoUrl: url }),
   setIsRecording: (isRecording) => set({ isRecording }),
@@ -102,6 +103,10 @@ export const useRecordingStore = create<RecordingState>((set) => ({
   setIsProcessing: (isProcessing) => set({ isProcessing }),
   setError: (error) => set({ error }),
   setAISettings: (settings) => set({ aiSettings: settings }),
+  setOpenAIApiKey: (key) => {
+    localStorage.setItem('openAIApiKey', key);
+    set({ openAIApiKey: key });
+  },
   addLetterTemplate: (template) => set((state) => ({
     letterTemplates: [...state.letterTemplates, template]
   })),

--- a/src/types.ts
+++ b/src/types.ts
@@ -39,6 +39,7 @@ export interface RecordingState {
   isProcessing: boolean;
   error: string | null;
   aiSettings: AISettings;
+  openAIApiKey: string;
   logoUrl: string;
   setLogoUrl: (url: string) => void;
   setIsRecording: (isRecording: boolean) => void;
@@ -56,6 +57,7 @@ export interface RecordingState {
   setIsProcessing: (isProcessing: boolean) => void;
   setError: (error: string | null) => void;
   setAISettings: (settings: AISettings) => void;
+  setOpenAIApiKey: (key: string) => void;
   addLetterTemplate: (template: LetterTemplate) => void;
   updateLetterTemplate: (template: LetterTemplate) => void;
   deleteLetterTemplate: (id: string) => void;


### PR DESCRIPTION
## Summary
- allow storing and retrieving the OpenAI API key
- remove Deepgram configuration
- document where to enter the OpenAI API key

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6887b05897b08326bf2ffd32e8456394