### PR TITLE
Fix SpeechRecognition initialization

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+    <link rel="icon" type="image/png" href="/akos-logo.png" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>AKOS - Transcription Médicale</title>
   </head>

--- a/src/services/transcription.ts
+++ b/src/services/transcription.ts
@@ -32,8 +32,14 @@ async function initializeRecognition(
   stream: MediaStream,
   onTranscript: (transcript: string) => void
 ): Promise<SpeechRecognition> {
-  const SpeechRecognition = window.SpeechRecognition || window.webkitSpeechRecognition;
-  const newRecognition = new SpeechRecognition();
+  const SpeechRecognitionCtor =
+    (window as any).SpeechRecognition ||
+    // @ts-ignore - vendor-prefixed API for some browsers
+    (window as any).webkitSpeechRecognition;
+  if (!SpeechRecognitionCtor || typeof SpeechRecognitionCtor !== 'function') {
+    throw new Error('API SpeechRecognition non prise en charge par ce navigateur.');
+  }
+  const newRecognition = new SpeechRecognitionCtor();
 
   // Mode continu sans résultats intermédiaires
   newRecognition.continuous = true;


### PR DESCRIPTION
## Summary
- ensure SpeechRecognition constructor exists before instantiation
- use AKOS logo as favicon instead of missing vite.svg

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_688a3f378cf08326bd4da0d14563d74d