### PR TITLE
Improve unsupported browser handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@
 - Node.js 18+
 - Navigateur moderne avec support de l'API Web Speech
 - Microphone fonctionnel
+- L'application fonctionne uniquement dans un contexte HTTPS
+- Google Chrome ou Microsoft Edge sont recommandés
 
 ## Installation
 ```bash

--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+    <link rel="icon" type="image/png" href="/akos-logo.png" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>AKOS - Transcription Médicale</title>
   </head>

--- a/src/components/Controls.tsx
+++ b/src/components/Controls.tsx
@@ -40,6 +40,13 @@ export const Controls: React.FC = () => {
   }, []);
 
   const handleStartRecording = async () => {
+    const supportsSpeechRecognition =
+      'SpeechRecognition' in window || 'webkitSpeechRecognition' in window;
+    if (!supportsSpeechRecognition) {
+      setError('Votre navigateur ne supporte pas la reconnaissance vocale. Utilisez Chrome ou Edge en HTTPS.');
+      return;
+    }
+
     try {
       const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
       setAudioStream(stream);

--- a/src/services/transcription.ts
+++ b/src/services/transcription.ts
@@ -32,8 +32,14 @@ async function initializeRecognition(
   stream: MediaStream,
   onTranscript: (transcript: string) => void
 ): Promise<SpeechRecognition> {
-  const SpeechRecognition = window.SpeechRecognition || window.webkitSpeechRecognition;
-  const newRecognition = new SpeechRecognition();
+  const SpeechRecognitionCtor =
+    (window as any).SpeechRecognition ||
+    // @ts-ignore - vendor-prefixed API for some browsers
+    (window as any).webkitSpeechRecognition;
+  if (!SpeechRecognitionCtor || typeof SpeechRecognitionCtor !== 'function') {
+    throw new Error('API SpeechRecognition non prise en charge par ce navigateur.');
+  }
+  const newRecognition = new SpeechRecognitionCtor();
 
   // Mode continu sans résultats intermédiaires
   newRecognition.continuous = true;


### PR DESCRIPTION
## Summary
- warn users when SpeechRecognition is unsupported before requesting the mic
- clarify browser requirements in README

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_688a3f378cf08326bd4da0d14563d74d